### PR TITLE
Update SHA256 checksums for solarboat formula

### DIFF
--- a/Formula/solarboat.rb
+++ b/Formula/solarboat.rb
@@ -1,7 +1,7 @@
 class Solarboat < Formula
     desc "Modern CLI for Infrastructure as Code and GitOps workflows"
     homepage "https://solarboat.io"
-    version "0.8.8"
+    version "0.8.9"
     license "BSD-3-Clause"
 
     if OS.mac?

--- a/Formula/solarboat.rb
+++ b/Formula/solarboat.rb
@@ -6,10 +6,10 @@ class Solarboat < Formula
 
     if OS.mac?
         url "https://github.com/devqik/solarboat/releases/download/v#{version}/solarboat-x86_64-apple-darwin.tar.gz"
-        sha256 "36859f33b66e91124614b83645a76ee52d0a7f5ac408364af94c732aff31a7b9"
+        sha256 "14c3e46a4aef5f11940511bbfbca71dd35f5654b1c45bb604d0b58b1980f6278"
     elsif OS.linux?
         url "https://github.com/devqik/solarboat/releases/download/v#{version}/solarboat-x86_64-unknown-linux-gnu.tar.gz"
-        sha256 "8114afad532ea510ed0cfdc885064e8cf99b4adb8fe69f4c4e3de2b9753c2cb3"
+        sha256 "4bdb22bc02a8d897721820ec3fa6b6c4e611bef5275207a869f6f50c5b66b323"
     end
 
     def install


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Homebrew formula to point to the latest release and correct artifact checksums.
> 
> - Bumps `version` to `0.8.9` in `Formula/solarboat.rb`
> - Updates `sha256` for macOS and Linux tarballs to match the new release artifacts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46bdaf600cc81c417cd13208171d1d4bb3ecafab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->